### PR TITLE
Added toASCIIString function, to render a digit in a terminal enviroment

### DIFF
--- a/src/mnist.js
+++ b/src/mnist.js
@@ -169,6 +169,30 @@ MNIST.draw = function(digit, context, offsetX, offsetY)
   context.putImageData(imageData, offsetX || 0, offsetY || 0);
 }
 
+// returns an ASCII representation of a digit received as parameter
+// it uses ASCII extended characters 176, 177 and 178 to represent different shades of gray
+// digit must be an array of 784 real numbers between 0 and 1
+MNIST.toASCIIString = function (digit)
+{
+  var mnistString = '';
+  for (var i = 0; i < digit.length; i++) {
+    var pixel = digit[i];
+
+    if (pixel === 0) {
+      pixel = ' ';
+    } else if (pixel > 0 && pixel < 0.333) {
+      pixel = '\u2591';
+    } else if (pixel >= 0.333 && pixel < 0.666) {
+      pixel = '\u2592';
+    } else {
+      pixel = '\u2593';
+    }
+
+    mnistString = mnistString + (i % 28 ? '' : '\n') + pixel;
+  }
+  
+  return mnistString;
+}
 
 // CommonJS & AMD
 if (typeof define !== 'undefined' && define.amd)


### PR DESCRIPTION
I added this function so I could render digits in terminal, given that I'm not using a browser.

It uses ASCII character 176, 177 and 178 (blocks with different shades) to render a representation of the digit.

Example Usage:

```javascript
var mnist = require('mnist')
var set = mnist.set(2, 1)

set.training.forEach(function (e) {
  console.log(mnist.toASCIIString(e.input))  
})
```

Output:

```
                            
                ░▓▓         
               ▒▓▓▓         
             ░▓▓▓▓░         
            ░▓▓▓▒░          
            ░▓▓▓▒           
           ░▓▓▓░            
           ▒▓▓░             
          ▓▓▓░              
         ░▓▓▒░              
        ░▒▓▓▒    ▒▒▒        
        ░▓▓▓░  ▒▒▓▓▓▓░      
        ░▓▓▓░ ░▓▓▓▓▓▓▓░     
       ░▒▓▓▒ ░▒▓▓▒░░▓▓░     
       ░▓▓▒ ░▓▓▓▒░░▓▓▒      
       ▒▓▓  ▓▓▓░ ░▓▓▒       
       ▒▓▓ ░▓▓▒ ░▓▓▒        
       ▒▓▓ ░▓▓▒▓▓▓░░        
       ░▓▓░▒▓▓▓▓▓░          
       ░▓▓▓▓▓▓▓▓▒           
        ░▓▓▓▓▒▒░            
                          
```